### PR TITLE
Move tfenv to the right section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -153,9 +153,10 @@
 
 ### Terraform
 
+- [tfenv](https://github.com/tfutils/tfenv) - A Terraform version manager inspired by rbenv.
+
 ### OpenTofu
 
-- [tfenv](https://github.com/tfutils/tfenv) - A Terraform version manager inspired by rbenv.
 - [tofuenv](https://github.com/tofuutils/tofuenv) - A OpenTofu version manager inspired by tfenv.
 - [tenv](https://github.com/tofuutils/tenv) - A versatile version manager for OpenTofu, Terraform and Terragrunt, written in Go.
 


### PR DESCRIPTION
I believe `tfenv` should be listed under terraform and not opentofu. 